### PR TITLE
Added configuration for setting default-mode when opening a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,22 @@
     ],
     "main": "./out/extension",
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "Parinfer",
+            "properties": {
+                "parinfer.defaultMode": {
+                    "type": "string",
+                    "enum": [
+                        "indent-mode",
+                        "paren-mode",
+                        "disabled"
+                    ],
+                    "default": "indent-mode",
+                    "description": "The default mode to be used when opening a new file."
+                }
+            }
+        },
         "keybindings": [
             {
                 "command": "parinfer.toggleMode",

--- a/src/parinfer.ts
+++ b/src/parinfer.ts
@@ -6,7 +6,8 @@ import {
   Position,
   Range,
   Selection,
-  window
+  window,
+  workspace
 } from "vscode";
 
 import { indentMode, parenMode, IPosition } from "parinfer";
@@ -135,7 +136,8 @@ export function parinfer(editor: TextEditor) {
 			});
 			editorStates.update((states: EditorStates) => states.set(editor, "indent-mode"));
 		} else {
-			editorStates.update((states: EditorStates) => states.set(editor, "indent-mode"));
+			let defaultMode : EditorState = workspace.getConfiguration('parinfer').get<EditorState>("defaultMode");
+			editorStates.update((states: EditorStates) => states.set(editor, defaultMode))
 		}
 	}
 }


### PR DESCRIPTION
Hey
First of all, thanks for porting this functionality into vscode, awesome stuff! =)

I had some issues with the plugin defaulting to indent-mode whenever i opened a clojure-file.
Not sure if this is intended behavior, or a bug. It seems like the `state` variable in `parinfer.ts` parinfer fn is always undefined when opening a file ?

I added a configuration for the default-mode, so that it still defaults to indent-mode, but this can be overridden in user-settings if needed by setting e.g. `"parinfer.defaultMode": "paren-mode"`