### PR TITLE
add extra languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
         "url": "https://github.com/shaunlebron/vscode-parinfer"
     },
     "activationEvents": [
-        "onLanguage:clojure"
+        "onLanguage:clojure",
+        "onLanguage:lisp",
+        "onLanguage:scheme",
+        "onLanguage:racket"
     ],
     "main": "./out/extension",
     "contributes": {


### PR DESCRIPTION
fix for https://github.com/shaunlebron/vscode-parinfer/issues/15

The [activation.onLanguage] event requires a [language identifier] instead of a file extension, so I'm just assuming the correct language identifiers exist for the few lisps I can name.

[activation.onLanguage]:https://code.visualstudio.com/docs/extensionAPI/activation-events#_activationeventsonlanguage
[language identifier]:https://code.visualstudio.com/docs/languages/identifiers