### PR TITLE
Add support for Fennel

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "onLanguage:lisp",
     "onLanguage:scheme",
     "onLanguage:racket",
-    "onLanguage:extempore"
+    "onLanguage:extempore",
+    "onLanguage:fennel"
   ],
   "contributes": {
     "configuration": {

--- a/src/parinfer.js
+++ b/src/parinfer.js
@@ -144,7 +144,8 @@ function helloEditor (editor) {
     editor.document.languageId === 'clojure' ||
     editor.document.languageId === 'scheme' ||
     editor.document.languageId === 'lisp' ||
-    editor.document.languageId === 'racket'
+    editor.document.languageId === 'racket' ||
+    editor.document.languageId === 'fennel'
   )
 
   editorStates.update(function (states) {


### PR DESCRIPTION
Hey,

I tried Parinfer out and noticed that it doesn't activate upon opening Fennel (a Lua-based Lisp) files. This PR fixes that by just adding Fennel to the array of detected languages and it seems to work fine. I hope it's OK.

Thanks for your work on the extension!